### PR TITLE
Update Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'http://rubygems.org'
 
-gem 'rest_client', '~> 1.7'
+gem 'rest-client', '~> 1.7'
 gem 'webmock', '~> 1.18'


### PR DESCRIPTION
Rails throw an error when rails server is launched

"WARNING: The rest_client gem is deprecated and will be removed from RubyGems. Please use rest-client gem instead."
