### PR TITLE
Rest client version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'http://rubygems.org'
 
-gem 'rest-client', '~> 1.7'
+gem 'rest-client', '~> 2.0'
 gem 'webmock', '~> 1.18'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,21 +4,23 @@ GEM
     addressable (2.4.0)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
-    domain_name (0.5.20160615)
+    domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
     hashdiff (0.3.0)
-    http-cookie (1.0.2)
+    http-cookie (1.0.3)
       domain_name (~> 0.5)
-    mime-types (2.99.2)
+    mime-types (3.2.2)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2018.0812)
     netrc (0.11.0)
-    rest-client (1.8.0)
+    rest-client (2.0.2)
       http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 3.0)
-      netrc (~> 0.7)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     safe_yaml (1.0.4)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.2)
+    unf_ext (0.0.7.5)
     webmock (1.24.6)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -28,8 +30,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  rest-client (~> 1.7)
+  rest-client (~> 2.0)
   webmock (~> 1.18)
 
 BUNDLED WITH
-   1.12.5
+   1.17.1

--- a/signaturit-sdk.gemspec
+++ b/signaturit-sdk.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
     s.license     = 'MIT'
 
-    s.add_dependency 'rest-client', '~> 1.7'
+    s.add_dependency 'rest-client', '~> 2.0'
 
     s.add_development_dependency 'webmock', '~> 1.18'
 end


### PR DESCRIPTION
This is just an update of rest-client since the latest version is now 2.0.2. The current version (1.7) causes errors while upgrading heroku stack to heroku-18. 

